### PR TITLE
Reset blocks array when drawing

### DIFF
--- a/generative-quilts.js
+++ b/generative-quilts.js
@@ -1,4 +1,4 @@
-let grid = 80, blocks = [], blockType, primaryColors, secondaryColors;
+let grid = 80, blocks, blockType, primaryColors, secondaryColors;
 
 function setup() {
   createCanvas(8 * grid, 8 * grid);
@@ -11,6 +11,8 @@ function setup() {
 function draw() {
   clear();
   randomSeed(seed);
+
+  blocks = [];
 
   if (document.querySelector('#randomColors').checked) {
     primaryColors = [webColor(), webColor(), webColor(), webColor()];


### PR DESCRIPTION
If we don't do this, the previously selected (and quilted) blocks stay in the array and are re-used for subsequent quilts